### PR TITLE
Ollama is not using the GPU instead of CPU.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Ensure shell scripts keep LF line endings
+*.sh text eol=lf

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,28 @@
 # Use the official Ollama image as base
 FROM ollama/ollama:latest
 
+# Install prerequisites for NVIDIA Container Toolkit
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    gnupg2 && \
+    rm -rf /var/lib/apt/lists/*
+
+# Configure NVIDIA Container Toolkit repository
+RUN curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg && \
+    curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list | \
+    sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | \
+    tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
+
+# Install NVIDIA Container Toolkit
+RUN apt-get update && \
+    export NVIDIA_CONTAINER_TOOLKIT_VERSION=1.18.2-1 && \
+    apt-get install -y \
+        nvidia-container-toolkit=${NVIDIA_CONTAINER_TOOLKIT_VERSION} \
+        nvidia-container-toolkit-base=${NVIDIA_CONTAINER_TOOLKIT_VERSION} \
+        libnvidia-container-tools=${NVIDIA_CONTAINER_TOOLKIT_VERSION} \
+        libnvidia-container1=${NVIDIA_CONTAINER_TOOLKIT_VERSION} && \
+    rm -rf /var/lib/apt/lists/*
+
 # Copy the init script into the container
 COPY init-ollama.sh /init-ollama.sh
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,9 @@ services:
   ollama:
     build: .                 # build from the Dockerfile in current directory
     container_name: ollama
+    runtime: nvidia
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=all
     volumes:
       - ollama_data:/root/.ollama
     ports:

--- a/web-chat/style.css
+++ b/web-chat/style.css
@@ -1,17 +1,19 @@
 .chat-container {
-  max-width: 800px;
-  margin: 40px auto;
+  width: 100%;
+  height: 100vh;
+  margin: 0;
   background: #fff;
-  border-radius: 8px;
-  box-shadow: 0 2px 8px rgba(0,0,0,0.1);
-  padding: 24px;
+  border-radius: 0;
+  box-shadow: none;
+  padding: 16px;
   display: flex;
   flex-direction: column;
+  box-sizing: border-box;
 }
 
 .chat-log {
-  min-height: 300px;
-  max-height: 400px;
+  flex: 1;
+  min-height: 0;
   overflow-y: auto;
   margin-bottom: 16px;
   padding: 8px;


### PR DESCRIPTION
Force LF line endings for .sh files via .gitattributes to prevent Windows CRLF from breaking container startup scripts.
Widened the web chat UI to full-screen layout for improved usability.
Added NVIDIA Container Toolkit install steps and GPU runtime settings to enable GPU usage with Ollama.